### PR TITLE
Fixed invalid deposit invoke

### DIFF
--- a/src/main/java/com/clubobsidian/dynamicgui/economy/bukkit/VaultEconomy.java
+++ b/src/main/java/com/clubobsidian/dynamicgui/economy/bukkit/VaultEconomy.java
@@ -150,7 +150,7 @@ public class VaultEconomy implements Economy {
 		
 		try 
 		{
-			this.depositPlayerMethod.invoke(this.economy, amt.doubleValue());
+			this.depositPlayerMethod.invoke(this.economy, playerWrapper.getPlayer(), amt.doubleValue());
 		} 
 		catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) 
 		{


### PR DESCRIPTION
Was missing playerWrapper.getPlayer() under deposit, would return IllegalArgumentException: not enough arguments @ 153.